### PR TITLE
Added a view set for some filtering/querying functionality in the assignments app

### DIFF
--- a/backend/assignments/views.py
+++ b/backend/assignments/views.py
@@ -6,6 +6,12 @@ from assignments import models
 from rest_framework import viewsets
 from django_filters import rest_framework as filters
 from rest_framework.filters import OrderingFilter, SearchFilter
+# below imports are for filtering / querying
+from rest_framework.permissions import IsAuthenticated
+from assignments.models import FlaggedSubmission
+from assignments.serializers import FlaggedSubmissionSerializer
+from users.permissions import is_admin 
+# from courses.models import ProfessorClassSection
 
 class StudentVS(viewsets.ModelViewSet):
     """Student Model ViewSet."""
@@ -94,8 +100,41 @@ class ConfirmedCheaterVS(viewsets.ModelViewSet):
     ordering = ['confirmed_date']
 
 
+# an extension of the flaggedSubmissionVS. It supports searching by file name and professor. Only lets a professor see their classes,
+# flaggedSubmissionVS is more suitable to be used by an admin, since it shows data from all classes. 
+class PlagiarismReportViewSet(viewsets.ModelViewSet):
+    """
+    Returns plagiarism reports (flagged submissions) filtered by semester and/or course,
+    but only for courses the authenticated professor is assigned to.
+    """
+    # This lets DRF use FlaggedSubmissionSerializer to convert FlaggedSubmission model instances into 
+    #JSON data before sending it in the API response.
+    serializer_class = FlaggedSubmissionSerializer
+    permission_classes = [IsAuthenticated]
+    filter_backends = [filters.DjangoFilterBackend, OrderingFilter, SearchFilter]
+    filterset_fields = [
+        'submission__assignment__class_instance_id', 
+        'submission__assignment__class_instance__semester',
+        'submission__assignment__class_instance__profclassect__semester_id'
+    ]
+    ordering_fields = [
+        'submission__created_at',
+        'submission__professor__user__first_name',
+        'file_name',
+        'percentage'
+    ]
+    search_fields = [
+        'file_name',
+        'submission__professor__user__first_name'
+    ]
 
-
-
-
+    def get_queryset(self):
+        user = self.request.user
+        
+        # Admins should see all flagged submissions. is_admin is from users/permissions.py
+        if is_admin(user):
+            return FlaggedSubmission.objects.all()
+        else:
+            professor = user.user_professor
+            return FlaggedSubmission.objects.filter(submission__professor=professor).distinct()
 


### PR DESCRIPTION
# Summary
This PR adds some filtering in the assignments app. It shows professors and TA's only the classes they are assigned to, and every class for admins. It also allows users to filter and order plagiarism reports further. 

# Description
So basically, this view set also uses the FlaggedSubmission table in models.py. So far each table just has one VS, but I added this one for PlagiarismReports to add to the filtering / ordering functionality when a user is looking at these reports. the FlaggedSubmissionVS is basically an "anyone can enter" VS, as long as their authenticated. PlaigarismReportsViewSet does a couple things:

The view set has extensive options for filtering, ordering, and sorting. If you're unfamiliar with what a field like this ['submission__assignment__class_instance__semester'] could do, it basically serves as a path from our starting table to the table with the variable we want to access and do filtering / ordering / searching with. Since this uses the FlaggedSubmission serializer, it starts from that table, and to get a 'semester' I need to follow the path defined above. A double underscore means we use the table dedicated to that variable. I.e. we start at the submission col in FlaggedSubmission, then __ represents going into the actual submission table. Then we access the assignment variable there, and so on.

The view set uses the helper function is_admin from the permissions.py file from the previous role-based access PR. Admins will be able to see all reports. Otherwise, the professor / ta will only see reports for classes and sections they're assigned to.


# Unit Tests
4. No tests.

Unit tests coming soon

# PR Reviews
Anyone on the backend team could review this.
